### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/input/plugins/YtdlInputStream.cxx
+++ b/src/input/plugins/YtdlInputStream.cxx
@@ -91,7 +91,7 @@ size_t YtdlInputStream::Read(std::unique_lock<Mutex> &lock, void *ptr, size_t sz
 	}
 }
 
-void YtdlInputStream::OnComplete(Ytdl::YtdlMonitor* monitor) {
+void YtdlInputStream::OnComplete([[maybe_unused]] Ytdl::YtdlMonitor* monitor) {
 	const std::lock_guard<Mutex> protect(mutex);
 	try {
 		tag = context->GetMetadata().GetTagBuilder().CommitNew();
@@ -104,7 +104,7 @@ void YtdlInputStream::OnComplete(Ytdl::YtdlMonitor* monitor) {
 	context = nullptr;
 }
 
-void YtdlInputStream::OnError(Ytdl::YtdlMonitor* monitor, std::exception_ptr e) {
+void YtdlInputStream::OnError([[maybe_unused]] Ytdl::YtdlMonitor* monitor, std::exception_ptr e) {
 	const std::lock_guard<Mutex> protect(mutex);
 	pending_exception = e;
 	context = nullptr;

--- a/src/input/plugins/YtdlTagScanner.cxx
+++ b/src/input/plugins/YtdlTagScanner.cxx
@@ -21,10 +21,10 @@ YtdlTagScanner::Start()
 	}
 }
 
-void YtdlTagScanner::OnComplete(Ytdl::YtdlMonitor* monitor) {
+void YtdlTagScanner::OnComplete([[maybe_unused]] Ytdl::YtdlMonitor* monitor) {
 	handler.OnRemoteTag(context->GetMetadata().GetTagBuilder().Commit());
 }
 
-void YtdlTagScanner::OnError(Ytdl::YtdlMonitor* monitor, std::exception_ptr e) {
+void YtdlTagScanner::OnError([[maybe_unused]] Ytdl::YtdlMonitor* monitor, std::exception_ptr e) {
 	handler.OnRemoteTagError(e);
 }

--- a/src/lib/ytdl/Invoke.cxx
+++ b/src/lib/ytdl/Invoke.cxx
@@ -137,7 +137,7 @@ YtdlProcess::Process()
 }
 
 bool
-YtdlMonitor::OnSocketReady(unsigned flags) noexcept
+YtdlMonitor::OnSocketReady([[maybe_unused]] unsigned flags) noexcept
 {
 	try {
 		// TODO: repeatedly call Process and wait for EWOULDBLOCK?

--- a/src/lib/ytdl/Parser.cxx
+++ b/src/lib/ytdl/Parser.cxx
@@ -47,6 +47,7 @@ class ParserContext {
 			case ParseContinue::CANCEL:
 				return 0;
 		}
+		return 0;
 	}
 
 public:

--- a/src/playlist/plugins/YtdlPlaylistPlugin.cxx
+++ b/src/playlist/plugins/YtdlPlaylistPlugin.cxx
@@ -34,7 +34,7 @@ static const char *const playlist_ytdl_schemes[] = {
 };
 
 static std::unique_ptr<SongEnumerator>
-playlist_ytdl_open_uri(const char *uri, Mutex &mutex)
+playlist_ytdl_open_uri(const char *uri, [[maybe_unused]] Mutex &mutex)
 {
 	uri = ytdl_init->UriSupported(uri);
 	if (!uri) {


### PR DESCRIPTION
Mostly just adding `[[maybe_unused]]` to function params.