### PR TITLE
Fix playlist order

### DIFF
--- a/src/lib/ytdl/TagHandler.cxx
+++ b/src/lib/ytdl/TagHandler.cxx
@@ -17,7 +17,7 @@ TagHandler::SortEntries()
 		inline bool
 		operator() (const TagHandler& tag0, const TagHandler& tag1)
 		{
-			return tag0.playlist_index < tag1.playlist_index;
+			return tag0.playlist_index > tag1.playlist_index;
 		}
 	};
 

--- a/src/playlist/plugins/YtdlPlaylistPlugin.cxx
+++ b/src/playlist/plugins/YtdlPlaylistPlugin.cxx
@@ -56,13 +56,13 @@ playlist_ytdl_open_uri(const char *uri, [[maybe_unused]] Mutex &mutex)
 		url.insert(0, "ytdl://");
 		songs.emplace_front(url.c_str(), std::move(playlist));
 	} else {
+		// The entries are reversed already, so don't need to reverse in the end
 		for (auto &entry : metadata.GetEntries()) {
 			std::string url = entry.GetWebpageURL().empty()
 				? entry.GetURL() : entry.GetWebpageURL();
 			url.insert(0, "ytdl://");
 			songs.emplace_front(url.c_str(), entry.GetTagBuilder().Commit());
 		}
-		songs.reverse();
 	}
 
 	return std::make_unique<MemorySongEnumerator>(std::move(songs));


### PR DESCRIPTION
Change playlist sorting to sort in reverse order in case playlist_index is added back in the future.
Remove `songs.reverse()`.
Fixes #8 