### PR TITLE
Disable youtube-dl plugin on windows and android

### DIFF
--- a/src/lib/ytdl/meson.build
+++ b/src/lib/ytdl/meson.build
@@ -6,6 +6,10 @@ else
   if not enable_ytdl and ytdl_feature.enabled()
     error('youtube-dl requires CURL and libyajl')
   endif
+
+  if is_windows or is_android
+    error('youtube-dl not supported on this platform')
+  endif
 endif
 conf.set('ENABLE_YTDL', enable_ytdl)
 if not enable_ytdl

--- a/src/lib/ytdl/meson.build
+++ b/src/lib/ytdl/meson.build
@@ -1,5 +1,6 @@
 ytdl_feature = get_option('youtube-dl')
-if ytdl_feature.disabled()
+
+if ytdl_feature.disabled() or ytdl_feature.auto() and (is_windows or is_android)
   enable_ytdl = false
 else
   enable_ytdl = curl_dep.found() and yajl_dep.found()
@@ -11,8 +12,11 @@ else
     error('youtube-dl not supported on this platform')
   endif
 endif
+
 conf.set('ENABLE_YTDL', enable_ytdl)
+
 if not enable_ytdl
+  ytdl_dep = dependency('', required: false)
   subdir_done()
 endif
 


### PR DESCRIPTION
#16 

Just a platform check in the build script. I'm not 100% sure which platform are supported which are not. So I just added Windows and Android into the check. It'll probably work on Haiku and OSX (I have no idea, just hoping).