### PR TITLE
Recreate CurlInputStream with a new URL when it fails

### DIFF
--- a/src/input/InputStream.hxx
+++ b/src/input/InputStream.hxx
@@ -36,7 +36,7 @@ class InputStream {
 public:
 	typedef ::offset_type offset_type;
 
-private:
+protected:
 	/**
 	 * The absolute URI which was used to open this stream.
 	 */

--- a/src/input/ProxyInputStream.hxx
+++ b/src/input/ProxyInputStream.hxx
@@ -87,11 +87,11 @@ protected:
 	void CopyAttributes();
 
 	/* virtual methods from class InputStreamHandler */
-	void OnInputStreamReady() noexcept override {
+	virtual void OnInputStreamReady() noexcept override {
 		InvokeOnReady();
 	}
 
-	void OnInputStreamAvailable() noexcept override {
+	virtual void OnInputStreamAvailable() noexcept override {
 		InvokeOnAvailable();
 	}
 };

--- a/src/input/plugins/YtdlInputStream.cxx
+++ b/src/input/plugins/YtdlInputStream.cxx
@@ -3,7 +3,7 @@
 #include "tag/Tag.hxx"
 
 YtdlInputStream::YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &event_loop) noexcept
-	:InputStream(_uri, _mutex)
+	:ProxyInputStream(_uri, _mutex)
 {
 	try {
 		context = Ytdl::InvokeContext::Invoke(_uri, Ytdl::PlaylistMode::SINGLE, event_loop, *this);
@@ -15,24 +15,6 @@ YtdlInputStream::YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &eve
 YtdlInputStream::~YtdlInputStream() noexcept {
 }
 
-const char *YtdlInputStream::GetURI() const noexcept {
-	if (inner != nullptr) {
-		return inner->GetURI();
-	} else {
-		return InputStream::GetURI();
-	}
-}
-
-void YtdlInputStream::SyncFields() noexcept {
-	seekable = inner->IsSeekable();
-	offset = inner->GetOffset();
-	if (inner->KnownSize()) {
-		size = inner->GetSize();
-	} else {
-		size = UNKNOWN_SIZE;
-	}
-}
-
 void YtdlInputStream::Check() {
 	if (pending_exception != nullptr) {
 		std::exception_ptr ex = pending_exception;
@@ -40,69 +22,25 @@ void YtdlInputStream::Check() {
 		std::rethrow_exception(ex);
 	}
 
-	if (inner != nullptr) {
-		inner->Check();
-	}
-}
-
-void YtdlInputStream::Update() noexcept {
-	if (inner != nullptr) {
-		inner->Update();
-		if (!ready && inner->IsReady()) {
-			SetMimeType(inner->GetMimeType());
-			SetReady();
-		}
-		if (inner->IsReady()) {
-			SyncFields();
-		}
-	}
-}
-
-void YtdlInputStream::Seek(std::unique_lock<Mutex> &lock, offset_type by_offset) {
-	if (inner != nullptr) {
-		inner->Seek(lock, by_offset);
-		SyncFields();
-	}
-}
-
-gcc_pure
-bool YtdlInputStream::IsEOF() const noexcept {
-	if (inner != nullptr) {
-		return inner->IsEOF();
-	} else {
-		return false;
+	if (input != nullptr) {
+		input->Check();
 	}
 }
 
 std::unique_ptr<Tag> YtdlInputStream::ReadTag() noexcept {
 	if (tag != nullptr) {
 		return std::move(tag);
-	} else if (inner != nullptr) {
-		return inner->ReadTag();
+	} else if (input != nullptr) {
+		return input->ReadTag();
 	} else {
 		return nullptr;
 	}
 }
 
-gcc_pure
-bool YtdlInputStream::IsAvailable() noexcept {
-	if (inner != nullptr) {
-		return inner->IsAvailable();
-	} else {
-		return pending_exception != nullptr;
-	}
-}
-
-gcc_nonnull_all
 size_t YtdlInputStream::Read(std::unique_lock<Mutex> &lock, void *ptr, size_t sz) {
-	if (inner != nullptr) {
+	if(input)
 		context = nullptr;
-		size_t res = inner->Read(lock, ptr, sz);
-		SyncFields();
-		return res;
-	} else {
-		throw std::runtime_error("youtube-dl stream not ready for reading");
-	}
+	return ProxyInputStream::Read(lock, ptr, sz);
 }
 
 void YtdlInputStream::OnComplete([[maybe_unused]] Ytdl::YtdlMonitor* monitor) {
@@ -114,9 +52,8 @@ void YtdlInputStream::OnComplete([[maybe_unused]] Ytdl::YtdlMonitor* monitor) {
 		}
 
 		tag = context->GetMetadata().GetTagBuilder().CommitNew();
-		inner = OpenCurlInputStream(context->GetMetadata().GetURL().c_str(),
-			context->GetMetadata().GetHeaders(), mutex);
-		inner->SetHandler(this);
+		SetInput(OpenCurlInputStream(context->GetMetadata().GetURL().c_str(),
+			context->GetMetadata().GetHeaders(), mutex));
 	} catch (...) {
 		pending_exception = std::current_exception();
 		SetReady(); // Notify the handler so it doesn't stuck waiting
@@ -127,12 +64,4 @@ void YtdlInputStream::OnError([[maybe_unused]] Ytdl::YtdlMonitor* monitor, std::
 	const std::lock_guard<Mutex> protect(mutex);
 	pending_exception = e;
 	SetReady();
-}
-
-void YtdlInputStream::OnInputStreamReady() noexcept {
-	InvokeOnReady();
-}
-
-void YtdlInputStream::OnInputStreamAvailable() noexcept {
-	InvokeOnAvailable();
 }

--- a/src/input/plugins/YtdlInputStream.cxx
+++ b/src/input/plugins/YtdlInputStream.cxx
@@ -2,17 +2,21 @@
 #include "CurlInputPlugin.hxx"
 #include "tag/Tag.hxx"
 
-YtdlInputStream::YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &event_loop) noexcept
-	:ProxyInputStream(_uri, _mutex)
+YtdlInputStream::YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &_event_loop) noexcept
+	:ProxyInputStream(_uri, _mutex), event_loop(_event_loop)
 {
-	try {
-		context = Ytdl::InvokeContext::Invoke(_uri, Ytdl::PlaylistMode::SINGLE, event_loop, *this);
-	} catch (...) {
-		pending_exception = std::current_exception();
-	}
+	InvokeYtdl();
 }
 
 YtdlInputStream::~YtdlInputStream() noexcept {
+}
+
+void YtdlInputStream::InvokeYtdl() {
+	try {
+		context = Ytdl::InvokeContext::Invoke(uri.c_str(), Ytdl::PlaylistMode::SINGLE, event_loop, *this);
+	} catch (...) {
+		pending_exception = std::current_exception();
+	}
 }
 
 void YtdlInputStream::Check() {
@@ -52,6 +56,7 @@ void YtdlInputStream::OnComplete([[maybe_unused]] Ytdl::YtdlMonitor* monitor) {
 		}
 
 		tag = context->GetMetadata().GetTagBuilder().CommitNew();
+
 		SetInput(OpenCurlInputStream(context->GetMetadata().GetURL().c_str(),
 			context->GetMetadata().GetHeaders(), mutex));
 	} catch (...) {
@@ -64,4 +69,24 @@ void YtdlInputStream::OnError([[maybe_unused]] Ytdl::YtdlMonitor* monitor, std::
 	const std::lock_guard<Mutex> protect(mutex);
 	pending_exception = e;
 	SetReady();
+}
+
+void YtdlInputStream::OnInputStreamReady() noexcept {
+
+	// This can be triggered when CurlInputStream fails. When that happens, try
+	// to invoke youtube-dl again and get a new url.
+	if(input) {
+		try {
+			input->Check();
+			retry_counter = 0;
+		} catch(...) {
+			if(retry_counter < MAX_RETRY) {
+				input = nullptr;
+				InvokeYtdl();
+				retry_counter++;
+			}
+		}
+	}
+
+	ProxyInputStream::OnInputStreamReady();
 }

--- a/src/input/plugins/YtdlInputStream.hxx
+++ b/src/input/plugins/YtdlInputStream.hxx
@@ -1,44 +1,30 @@
 #ifndef MPD_INPUT_YTDL_STREAM_HXX
 #define MPD_INPUT_YTDL_STREAM_HXX
 
-#include "../InputStream.hxx"
-#include "../Handler.hxx"
+#include "../ProxyInputStream.hxx"
 #include "lib/ytdl/Invoke.hxx"
 
 class Tag;
 
-class YtdlInputStream : public InputStream, public InputStreamHandler, public Ytdl::YtdlHandler {
+class YtdlInputStream : public ProxyInputStream, public Ytdl::YtdlHandler {
 	std::unique_ptr<Ytdl::InvokeContext> context;
 	std::unique_ptr<Tag> tag;
-	InputStreamPtr inner;
 	std::exception_ptr pending_exception;
-
-	void SyncFields() noexcept;
 
 public:
 	YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &event_loop) noexcept;
 
-	virtual ~YtdlInputStream() noexcept;
-	virtual void Check();
-	virtual void Update() noexcept;
-	virtual void Seek(std::unique_lock<Mutex> &lock, offset_type by_offset);
-	virtual const char *GetURI() const noexcept;
+	~YtdlInputStream() noexcept;
+	void Check() override;
 
-	gcc_pure
-	virtual bool IsEOF() const noexcept;
-	virtual std::unique_ptr<Tag> ReadTag() noexcept;
-
-	gcc_pure
-	virtual bool IsAvailable() noexcept;
+	std::unique_ptr<Tag> ReadTag() noexcept override;
 
 	gcc_nonnull_all
-	virtual size_t Read(std::unique_lock<Mutex> &lock, void *ptr, size_t size);
+	size_t Read(std::unique_lock<Mutex> &lock, void *ptr, size_t size);
 
-	void OnComplete(Ytdl::YtdlMonitor* monitor);
-	void OnError(Ytdl::YtdlMonitor* monitor, std::exception_ptr e);
 
-	virtual void OnInputStreamReady() noexcept;
-	virtual void OnInputStreamAvailable() noexcept;
+	void OnComplete(Ytdl::YtdlMonitor* monitor) override;
+	void OnError(Ytdl::YtdlMonitor* monitor, std::exception_ptr e) override;
 };
 
 #endif

--- a/src/input/plugins/YtdlInputStream.hxx
+++ b/src/input/plugins/YtdlInputStream.hxx
@@ -5,11 +5,20 @@
 #include "lib/ytdl/Invoke.hxx"
 
 class Tag;
+class InputStreamHandler;
 
 class YtdlInputStream : public ProxyInputStream, public Ytdl::YtdlHandler {
+	static const int MAX_RETRY = 1;
+
 	std::unique_ptr<Ytdl::InvokeContext> context;
 	std::unique_ptr<Tag> tag;
 	std::exception_ptr pending_exception;
+	InputStreamHandler *handler = nullptr;
+	EventLoop &event_loop;
+
+	int retry_counter = 0;
+
+	void InvokeYtdl();
 
 public:
 	YtdlInputStream(const char *_uri, Mutex &_mutex, EventLoop &event_loop) noexcept;
@@ -22,9 +31,10 @@ public:
 	gcc_nonnull_all
 	size_t Read(std::unique_lock<Mutex> &lock, void *ptr, size_t size);
 
-
 	void OnComplete(Ytdl::YtdlMonitor* monitor) override;
 	void OnError(Ytdl::YtdlMonitor* monitor, std::exception_ptr e) override;
+
+	void OnInputStreamReady() noexcept override;
 };
 
 #endif


### PR DESCRIPTION
#6

I made YtdlInputStream listen to OnInputStreamReady, which get's called when the inner CurlInputStream fails. It checks for that, then re-invoke youtube-dl to get a new URL if needed.

I haven't got the new rebase to upstream working, so I was working on the 0.22.x branch. There seem to be something wrong with the branches now that I can't merge it into ytdl branch. Maybe hold onto this PR for now until upstream rebasing is complete? And then I can cherry pick this into a new branch.